### PR TITLE
Lock Mojolicious to vers >=6.08, <=6.24

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -40,9 +40,10 @@ my $builder = Module::Build::Database->new(
     dist_abstract       => "The Useful Backend API",
     release_status      => 'stable',
     configure_requires => {
-        'Module::Build' => 0.39,
+        'Module::Build' => '0.39',
         'Module::Build::Mojolicious' => 0,
         'Module::Build::Database' => 0,
+        'Mojolicious' => '>= 6.08, <= 6.24',
         'Mojolicious::Plugin::InstallablePaths' => 0,
     },
     build_requires => {
@@ -54,7 +55,7 @@ my $builder = Module::Build::Database->new(
         'LWP::UserAgent' => 0,
         'Number::Bytes::Human' => 0,
         'Mojolicious::Plugin::YamlConfig' => 0,
-        'Mojolicious' => '6.08',
+        'Mojolicious' => '>= 6.08, <= 6.24',
         'Number::Format' => 0,
         'YAML::Syck'  => 0,
         'YAML::XS'    => 0,

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "unknown"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.421",
+   "generated_by" : "Module::Build version 0.4216",
    "license" : [
       "agpl_3"
    ],
@@ -26,6 +26,7 @@
             "Module::Build" : "0.39",
             "Module::Build::Database" : "0",
             "Module::Build::Mojolicious" : "0",
+            "Mojolicious" : ">= 6.08, <= 6.24",
             "Mojolicious::Plugin::InstallablePaths" : "0"
          }
       },
@@ -48,7 +49,7 @@
             "JSON::XS" : "0",
             "LWP::UserAgent" : "0",
             "Lingua::EN::Inflect" : "0",
-            "Mojolicious" : "6.08",
+            "Mojolicious" : ">= 6.08, <= 6.24",
             "Mojolicious::Plugin::InstallablePaths" : "0",
             "Mojolicious::Plugin::YamlConfig" : "0",
             "Number::Bytes::Human" : "0",
@@ -350,5 +351,6 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.40"
+   "version" : "1.40",
+   "x_serialization_backend" : "JSON::PP version 2.27300"
 }

--- a/META.yml
+++ b/META.yml
@@ -10,9 +10,10 @@ configure_requires:
   Module::Build: '0.39'
   Module::Build::Database: '0'
   Module::Build::Mojolicious: '0'
+  Mojolicious: '>= 6.08, <= 6.24'
   Mojolicious::Plugin::InstallablePaths: '0'
 dynamic_config: 1
-generated_by: 'Module::Build version 0.421, CPAN::Meta::Converter version 2.142690'
+generated_by: 'Module::Build version 0.4216, CPAN::Meta::Converter version 2.150005'
 license: open_source
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -218,7 +219,7 @@ requires:
   JSON::XS: '0'
   LWP::UserAgent: '0'
   Lingua::EN::Inflect: '0'
-  Mojolicious: '6.08'
+  Mojolicious: '>= 6.08, <= 6.24'
   Mojolicious::Plugin::InstallablePaths: '0'
   Mojolicious::Plugin::YamlConfig: '0'
   Number::Bytes::Human: '0'
@@ -244,3 +245,4 @@ requires:
   YAML::Syck: '0'
   YAML::XS: '0'
 version: '1.40'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.012'


### PR DESCRIPTION
Current tests fail beginning with Mojolicious version somewhere between 6.24 and
6.51.  The error exhibited is:
    Can't call method "resource" on an undefined value at
    /home/travis/build/USGCRP/gcis/blib/lib/Tuba.pm line 381.

Tuba.pm line 381 as of this checkin is:
        $r->lookup('select_platform')->resource('instrument_instance', {
            path_base => "instrument",
            identifier => "instrument_identifier",
        });

$r->lookup('select_platform') appears to now return UNDEF as of at least v6.51, and
is still an issue as of v6.56.
